### PR TITLE
[fix]:[SCRUM-31] CD 과정에서 빌드 방식 변경

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Gradle 빌드 실행
-        run: ./gradlew clean build -x test
+        run: ./gradlew clean build
 
       - name: fat jar만 복사하여 app.jar로 이름 변경
         run: |


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- CD 수행 시 테스트를 수행하지 않으면 Spring REST Docs의 asciidoc 문서 경로가 생성되지 않아 에러 발생
- CD 과정 중 빌드 시에도 테스트를 수행하도록 cd.yml 수정

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드는 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 배포 과정에서 빌드 시 테스트가 자동으로 실행되도록 워크플로우가 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->