### PR TITLE
[fix]:[SCRUM-37] 요금제 목록 조회 테스트 수정

### DIFF
--- a/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
@@ -32,12 +32,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+@ActiveProfiles("test")
 @WebMvcTest(PlanController.class)
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 class PlanControllerTest {

--- a/src/test/java/com/ixi_U/plan/repository/PlanRepositoryTest.java
+++ b/src/test/java/com/ixi_U/plan/repository/PlanRepositoryTest.java
@@ -18,12 +18,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.neo4j.DataNeo4jTest;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.Neo4jContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
+@ActiveProfiles("test")
 @DataNeo4jTest
 @Testcontainers
 class PlanRepositoryTest {


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 테스트 코드에 `@ActiveProfile`을 추가했습니다.

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드는 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **테스트**
  - 테스트 클래스에서 "test" Spring 프로필이 활성화되도록 설정하였습니다.
  - 일부 테스트에서 중복된 코드가 정리되고, 예외 메시지 검증이 상수 기반으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->