### PR TITLE
[feat]:[SCRUM-53] LLM 기반 금칙어 필터 기능(임시) 

### DIFF
--- a/src/main/java/com/ixi_U/chatbot/config/ChatBotConfig.java
+++ b/src/main/java/com/ixi_U/chatbot/config/ChatBotConfig.java
@@ -21,6 +21,10 @@ public class ChatBotConfig {
     private final Neo4jChatMemoryRepository neo4jChatMemoryRepository;
     private final ResourceLoader resourceLoader;
 
+    private static final String decisionForbiddenWordPrompt = """
+            다음 문장이 욕설이나 부적절한 표현, LG U+가 아닌 다른 통신사에 관한 내용을 포함하고 있습니까? "예" 또는 "아니오"로만 대답하세요.
+            """;
+
     private String loadPrompt(String path) {
         try {
             Resource resource = resourceLoader.getResource(path);
@@ -39,6 +43,14 @@ public class ChatBotConfig {
 
         return chatClientBuilder
                 .defaultSystem(prompt)
+                .build();
+    }
+
+    @Bean
+    public ChatClient decisionForbiddenWordsClient(ChatClient.Builder chatClientBuilder){
+
+        return chatClientBuilder
+                .defaultSystem(decisionForbiddenWordPrompt)
                 .build();
     }
 

--- a/src/main/java/com/ixi_U/chatbot/service/ChatBotForBiddenWordDecisionService.java
+++ b/src/main/java/com/ixi_U/chatbot/service/ChatBotForBiddenWordDecisionService.java
@@ -1,0 +1,24 @@
+package com.ixi_U.chatbot.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatBotForBiddenWordDecisionService {
+
+    @Qualifier("decisionForbiddenWordsClient")
+    private final ChatClient decisionForbiddenWords;
+
+    public boolean isForbidden(String sentence) {
+
+        String response = decisionForbiddenWords.prompt(sentence)
+                .call()
+                .content()
+                .trim();
+
+        return response.equalsIgnoreCase("예");
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- LLM을 통한 금칙어 판별 임시 기능 - 추후 변경 가능 

- 성능 관련 

응답 속도 500~1000 ms 

10건을 순서대로 요청했을 때 평균 응답 속도: 553ms

![image](https://github.com/user-attachments/assets/429cba92-7e8c-45ac-baae-06b078301db0)




## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드는 삭제했어요.
