### PR TITLE
[feat]:[SCRUM-64] 회원 시스템 스프링 시큐리티 인증 객체 주입

### DIFF
--- a/src/main/java/com/ixi_U/user/controller/SubscribedController.java
+++ b/src/main/java/com/ixi_U/user/controller/SubscribedController.java
@@ -6,8 +6,8 @@ import com.ixi_U.user.service.SubscribedService;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,18 +23,18 @@ public class SubscribedController {
         this.subscribedService = subscribedService;
     }
 
-    @PostMapping("/{userId}")
+    @PostMapping
     public ResponseEntity<Void> updateSubscribed(
-            @PathVariable("userId") String userId,
+            @AuthenticationPrincipal String userId,
             @RequestBody @Valid CreateSubscribedRequest request) {
         subscribedService.updateSubscribed(userId, request);
 
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/{userId}/history")
+    @GetMapping("/history")
     public ResponseEntity<List<ShowSubscribedHistoryResponse>> showSubscribedHistoryByUserId(
-            @PathVariable String userId) {
+            @AuthenticationPrincipal String userId) {
         List<ShowSubscribedHistoryResponse> responses = subscribedService.findSubscribedHistoryByUserId(
                 userId);
         return ResponseEntity.ok(responses);

--- a/src/main/java/com/ixi_U/user/controller/UserController.java
+++ b/src/main/java/com/ixi_U/user/controller/UserController.java
@@ -20,8 +20,8 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/me")
-    public ResponseEntity<?> getMyPlan() {
-        List<SubscribedResponse> subscribedList = userService.getMySubscribedPlans();
+    public ResponseEntity<?> getMyPlan(@AuthenticationPrincipal String userId) {
+        List<SubscribedResponse> subscribedList = userService.getMySubscribedPlans(userId);
 
         if (subscribedList.isEmpty()) {
             return ResponseEntity.ok("아직 등록된 요금제가 없습니다.");

--- a/src/main/java/com/ixi_U/user/service/UserService.java
+++ b/src/main/java/com/ixi_U/user/service/UserService.java
@@ -8,7 +8,6 @@ import com.ixi_U.user.repository.SubscribedRepository;
 import com.ixi_U.user.repository.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,12 +22,7 @@ public class UserService {
         this.subscribedRepository = subscribedRepository;
     }
 
-    public List<SubscribedResponse> getMySubscribedPlans() {
-        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        String userId = principal instanceof String
-                ? (String) principal
-                : String.valueOf(principal);
-
+    public List<SubscribedResponse> getMySubscribedPlans(String userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RuntimeException("사용자 정보를 찾을 수 없습니다."));
 

--- a/src/test/java/com/ixi_U/user/controller/SubscribedControllerTest.java
+++ b/src/test/java/com/ixi_U/user/controller/SubscribedControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -33,6 +34,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -77,15 +80,27 @@ class SubscribedControllerTest {
             String userId = "test-user";
             CreateSubscribedRequest request = new CreateSubscribedRequest("plan-1");
 
+            // SecurityContext에 String principal로 직접 주입
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userId, null, List.of())
+            );
+            System.out.println(
+                    ">>> 테스트 principal: " + SecurityContextHolder.getContext().getAuthentication()
+                            .getPrincipal());
+
             // when
-            ResultActions result = mockMvc.perform(post("/subscribed/{userId}", userId)
+            ResultActions result = mockMvc.perform(post("/subscribed")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
                     .andDo(document("createSubscribed-success"));
 
             // then
             result.andExpect(status().isOk());
             verify(subscribedService).updateSubscribed(eq(userId), eq(request));
+
+            System.out.println(
+                    ">>> 응답 바디: " + result.andReturn().getResponse().getContentAsString());
         }
 
         @Test
@@ -95,15 +110,27 @@ class SubscribedControllerTest {
             String userId = "test-user";
             CreateSubscribedRequest invalidRequest = new CreateSubscribedRequest("");
 
+            // SecurityContext에 String principal로 직접 주입
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userId, null, List.of())
+            );
+            System.out.println(
+                    ">>> 테스트 principal: " + SecurityContextHolder.getContext().getAuthentication()
+                            .getPrincipal());
+
             // when
-            ResultActions result = mockMvc.perform(post("/subscribed/{userId}", userId)
+            ResultActions result = mockMvc.perform(post("/subscribed")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(invalidRequest)))
+                    .andDo(print())
                     .andDo(document("createSubscribed-error-plan-id-blank"));
 
             // then
             result.andExpect(status().isBadRequest());
             verifyNoInteractions(subscribedService);
+
+            System.out.println(
+                    ">>> 응답 바디: " + result.andReturn().getResponse().getContentAsString());
         }
 
         @Test
@@ -116,16 +143,28 @@ class SubscribedControllerTest {
             doThrow(new GeneralException(UserException.USER_NOT_FOUND))
                     .when(subscribedService).updateSubscribed(eq(userId), eq(request));
 
+            // SecurityContext에 String principal로 직접 주입
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userId, null, List.of())
+            );
+            System.out.println(
+                    ">>> 테스트 principal: " + SecurityContextHolder.getContext().getAuthentication()
+                            .getPrincipal());
+
             // when
-            ResultActions result = mockMvc.perform(post("/subscribed/{userId}", userId)
+            ResultActions result = mockMvc.perform(post("/subscribed")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
                     .andDo(document("createSubscribed-error-user-not-found"));
 
             // then
             result.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message")
                             .value(UserException.USER_NOT_FOUND.getMessage()));
+
+            System.out.println(
+                    ">>> 응답 바디: " + result.andReturn().getResponse().getContentAsString());
         }
 
         @Test
@@ -138,16 +177,28 @@ class SubscribedControllerTest {
             doThrow(new GeneralException(PlanException.PLAN_NOT_FOUND))
                     .when(subscribedService).updateSubscribed(eq(userId), eq(request));
 
+            // SecurityContext에 String principal로 직접 주입
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userId, null, List.of())
+            );
+            System.out.println(
+                    ">>> 테스트 principal: " + SecurityContextHolder.getContext().getAuthentication()
+                            .getPrincipal());
+
             // when
-            ResultActions result = mockMvc.perform(post("/subscribed/{userId}", userId)
+            ResultActions result = mockMvc.perform(post("/subscribed")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
                     .andDo(document("createSubscribed-error-plan-not-found"));
 
             // then
             result.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message")
                             .value(PlanException.PLAN_NOT_FOUND.getMessage()));
+
+            System.out.println(
+                    ">>> 응답 바디: " + result.andReturn().getResponse().getContentAsString());
         }
 
         @Test
@@ -160,16 +211,28 @@ class SubscribedControllerTest {
             doThrow(new GeneralException(PlanException.ALREADY_SUBSCRIBED_PLAN))
                     .when(subscribedService).updateSubscribed(eq(userId), eq(request));
 
+            // SecurityContext에 String principal로 직접 주입
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userId, null, List.of())
+            );
+            System.out.println(
+                    ">>> 테스트 principal: " + SecurityContextHolder.getContext().getAuthentication()
+                            .getPrincipal());
+
             // when
-            ResultActions result = mockMvc.perform(post("/subscribed/{userId}", userId)
+            ResultActions result = mockMvc.perform(post("/subscribed")
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
                     .andDo(document("createSubscribed-error-already-subscribed"));
 
             // then
             result.andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message")
                             .value(PlanException.ALREADY_SUBSCRIBED_PLAN.getMessage()));
+
+            System.out.println(
+                    ">>> 응답 바디: " + result.andReturn().getResponse().getContentAsString());
         }
     }
 
@@ -194,9 +257,20 @@ class SubscribedControllerTest {
             org.mockito.Mockito.when(subscribedService.findSubscribedHistoryByUserId(userId))
                     .thenReturn(responses);
 
+            // SecurityContext에 String userId를 principal로 직접 넣음
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userId, null, List.of())
+            );
+
+            // 로그: 테스트 시작 시 principal 출력
+            System.out.println(
+                    ">>> 테스트 principal: " + SecurityContextHolder.getContext().getAuthentication()
+                            .getPrincipal());
+
             // when
-            ResultActions result = mockMvc.perform(get("/subscribed/{userId}/history", userId)
+            ResultActions result = mockMvc.perform(get("/subscribed/history")
                             .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
                     .andDo(document("getSubscribedHistory-success"));
 
             // then
@@ -214,15 +288,29 @@ class SubscribedControllerTest {
             doThrow(new GeneralException(UserException.USER_NOT_FOUND))
                     .when(subscribedService).findSubscribedHistoryByUserId(userId);
 
+            // SecurityContext에 String principal로 직접 주입
+            SecurityContextHolder.getContext().setAuthentication(
+                    new UsernamePasswordAuthenticationToken(userId, null, List.of())
+            );
+            // principal 로그
+            System.out.println(
+                    ">>> 테스트 principal: " + SecurityContextHolder.getContext().getAuthentication()
+                            .getPrincipal());
+
             // when
-            ResultActions result = mockMvc.perform(get("/subscribed/{userId}/history", userId)
+            ResultActions result = mockMvc.perform(get("/subscribed/history")
                             .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
                     .andDo(document("getSubscribedHistory-error-user-not-found"));
 
             // then
             result.andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.message")
                             .value(UserException.USER_NOT_FOUND.getMessage()));
+
+            // 응답 바디 로그
+            String responseBody = result.andReturn().getResponse().getContentAsString();
+            System.out.println(">>> 응답 바디: " + responseBody);
         }
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 기존에 컨트롤러에서 String으로 받거나 CustomUser로 받아오던 매개변수들을  @AuthenticationPrincipal을 사용한 시큐리티 컨텍스트 기반 인증 정보 주입 방식으로 변경하였습니다. 

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 소원님이 만드셨던 "getMyPlan" 메서드도 동일 방식으로 수정해 두었습니다.

## ✅ 체크리스트
- [✅] PR 템플릿에 맞추어 작성했어요.
- [✅] PR에 적절한 라벨을 선택했어요.
- [✅] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [✅] 변경 내용에 대한 테스트를 진행했어요.
- [✅] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [✅] 로컬 서버에서 정상 동작을 확인했어요.
- [✅] 불필요한 코드는 삭제했어요.
