### PR TITLE
[fix]:[SCRUM-96] 요금제 목록 조회 시 로직 수정

### DIFF
--- a/src/main/java/com/ixi_U/plan/dto/PlanListDto.java
+++ b/src/main/java/com/ixi_U/plan/dto/PlanListDto.java
@@ -1,0 +1,15 @@
+package com.ixi_U.plan.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public record PlanListDto(String id, String name, String mobileDataLimitMb,
+                          String sharedMobileDataLimitMb,
+                          String callLimitMinutes,
+                          String messageLimit,
+                          int monthlyPrice,
+                          int priority,
+                          List<Map<String, Object>> singleBenefits,
+                          List<Map<String, Object>> bundledBenefits) {
+
+}

--- a/src/main/java/com/ixi_U/plan/dto/response/SortedPlanResponse.java
+++ b/src/main/java/com/ixi_U/plan/dto/response/SortedPlanResponse.java
@@ -1,9 +1,9 @@
 package com.ixi_U.plan.dto.response;
 
-import com.ixi_U.plan.dto.PlanSummaryDto;
+import com.ixi_U.plan.dto.PlanListDto;
 import org.springframework.data.domain.Slice;
 
-public record SortedPlanResponse(Slice<PlanSummaryDto> plans, String lastPlanId,
+public record SortedPlanResponse(Slice<PlanListDto> plans, String lastPlanId,
                                  int lastSortValue) {
 
 }

--- a/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
@@ -16,8 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ixi_U.benefit.entity.BenefitType;
 import com.ixi_U.common.exception.GeneralException;
+import com.ixi_U.plan.dto.PlanListDto;
 import com.ixi_U.plan.dto.PlanNameDto;
-import com.ixi_U.plan.dto.PlanSummaryDto;
 import com.ixi_U.plan.dto.request.GetPlansRequest;
 import com.ixi_U.plan.dto.request.SavePlanRequest;
 import com.ixi_U.plan.dto.response.BundledBenefitResponse;
@@ -170,12 +170,14 @@ class PlanControllerTest {
         void getPlansBySort() throws Exception {
 
             // given
-            PlanSummaryDto dto1 = new PlanSummaryDto("1", "요금제1", 10000, 2000, 300, 200, 29000, 5,
+            PlanListDto dto1 = new PlanListDto("1", "요금제1", "10GB", "2000", "300분", "200건", 29000,
+                    5,
                     List.of(), List.of());
-            PlanSummaryDto dto2 = new PlanSummaryDto("2", "요금제2", 8000, 1000, 200, 100, 19000, 3,
+            PlanListDto dto2 = new PlanListDto("2", "요금제2", "무제한", "2000", "기본제공", "기본제공", 19000, 3,
                     List.of(), List.of());
-            SortedPlanResponse response =
-                    new SortedPlanResponse(new SliceImpl<>(List.of(dto1, dto2)), "2", 3);
+
+            SortedPlanResponse response = new SortedPlanResponse(
+                    new SliceImpl<>(List.of(dto1, dto2)), "2", 3);
 
             given(planService.findPlans(PageRequest.ofSize(2), GetPlansRequest.of(
                     "ONLINE", "PRIORITY", null, null, null)))
@@ -186,11 +188,14 @@ class PlanControllerTest {
                             .param("size", "2")
                             .param("planTypeStr", "ONLINE")
                             .param("planSortOptionStr", "PRIORITY")
-                            // 보안필터를 통과시키려면 필요시 Mock 사용자 주입
                             .with(user("tester").roles("USER")))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.plans.content[0].id").value("1"))
+                    .andExpect(jsonPath("$.plans.content[0].mobileDataLimitMb").value("10GB"))
+                    .andExpect(jsonPath("$.plans.content[0].callLimitMinutes").value("300분"))
                     .andExpect(jsonPath("$.plans.content[1].id").value("2"))
+                    .andExpect(jsonPath("$.plans.content[1].mobileDataLimitMb").value("무제한"))
+                    .andExpect(jsonPath("$.plans.content[1].callLimitMinutes").value("기본제공"))
                     .andExpect(jsonPath("$.lastPlanId").value("2"))
                     .andExpect(jsonPath("$.lastSortValue").value(3))
                     .andDo(document("get-plans-sort-success"))
@@ -202,7 +207,7 @@ class PlanControllerTest {
         void getPlansBySearch() throws Exception {
 
             // given
-            PlanSummaryDto dto2 = new PlanSummaryDto("2", "요금제2", 8000, 1000, 200, 100, 19000, 3,
+            PlanListDto dto2 = new PlanListDto("2", "요금제2", "8GB", "1000", "200분", "100건", 19000, 3,
                     List.of(), List.of());
             SortedPlanResponse response =
                     new SortedPlanResponse(new SliceImpl<>(List.of(dto2)), "2", 3);

--- a/src/test/java/com/ixi_U/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/ixi_U/plan/service/PlanServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.ixi_U.common.exception.GeneralException;
-import com.ixi_U.plan.dto.PlanNameDto;
+import com.ixi_U.plan.dto.PlanListDto;
 import com.ixi_U.plan.dto.PlanSummaryDto;
 import com.ixi_U.plan.dto.request.GetPlansRequest;
 import com.ixi_U.plan.dto.response.SortedPlanResponse;
@@ -54,11 +54,25 @@ class PlanServiceTest {
             // given
             PageRequest pageable = PageRequest.ofSize(3);
 
-            PlanSummaryDto dto1 = new PlanSummaryDto("plan-A", "A 요금제", 5000, 1000, 200, 300, 29000, 1, List.of(), List.of());
-            PlanSummaryDto dto2 = new PlanSummaryDto("plan-B", "B 요금제", 3000, 500, 100, 200, 19000, 2, List.of(), List.of());
-            PlanSummaryDto dto3 = new PlanSummaryDto("plan-C", "C 요금제", 1000, 300, 50, 100, 9900, 3, List.of(), List.of());
+            PlanSummaryDto dto1 = new PlanSummaryDto("plan-A", "A 요금제", 5000, 1000, 200, 300, 29000,
+                    1, List.of(), List.of());
+            PlanSummaryDto dto2 = new PlanSummaryDto("plan-B", "B 요금제", 3000, 500, 100, 200, 19000,
+                    2, List.of(), List.of());
+            PlanSummaryDto dto3 = new PlanSummaryDto("plan-C", "C 요금제", 1000, 300, 50, 100, 9900, 3,
+                    List.of(), List.of());
 
-            Slice<PlanSummaryDto> slice = new SliceImpl<>(List.of(dto1, dto2, dto3), pageable, true);
+            Slice<PlanSummaryDto> slice = new SliceImpl<>(List.of(dto1, dto2, dto3), pageable,
+                    true);
+
+            PlanListDto dtoA = new PlanListDto("plan-A", "A 요금제", "5", "1", "2", "300", 29000, 1,
+                    List.of(), List.of());
+            PlanListDto dtoB = new PlanListDto("plan-B", "B 요금제", "3", "5", "100", "200", 19000, 2,
+                    List.of(), List.of());
+            PlanListDto dtoC = new PlanListDto("plan-C", "C 요금제", "1", "3", "50", "100", 9900, 3,
+                    List.of(), List.of());
+
+            Slice<PlanListDto> sliceList = new SliceImpl<>(List.of(dtoA, dtoB, dtoC), pageable,
+                    true);
 
             given(planRepository.findPlans(pageable, PlanType.from(planTypeStr),
                     PlanSortOption.from(planSortOptionStr), null, null, null))
@@ -70,7 +84,7 @@ class PlanServiceTest {
             );
 
             // then
-            assertThat(result.plans().getContent()).containsExactly(dto1, dto2, dto3);
+            assertThat(result.plans().getContent()).containsExactly(dtoA, dtoB, dtoC);
             verify(planRepository).findPlans(pageable, PlanType.from(planTypeStr),
                     PlanSortOption.from(planSortOptionStr), null, null, null
             );

--- a/src/test/java/com/ixi_U/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/ixi_U/plan/service/PlanServiceTest.java
@@ -64,11 +64,14 @@ class PlanServiceTest {
             Slice<PlanSummaryDto> slice = new SliceImpl<>(List.of(dto1, dto2, dto3), pageable,
                     true);
 
-            PlanListDto dtoA = new PlanListDto("plan-A", "A 요금제", "5", "1", "2", "300", 29000, 1,
+            PlanListDto dtoA = new PlanListDto("plan-A", "A 요금제", "5 GB", "1 GB", "200 분", "300 건",
+                    29000, 1,
                     List.of(), List.of());
-            PlanListDto dtoB = new PlanListDto("plan-B", "B 요금제", "3", "5", "100", "200", 19000, 2,
+            PlanListDto dtoB = new PlanListDto("plan-B", "B 요금제", "3 GB", "0 GB", "100 분", "200 건",
+                    19000, 2,
                     List.of(), List.of());
-            PlanListDto dtoC = new PlanListDto("plan-C", "C 요금제", "1", "3", "50", "100", 9900, 3,
+            PlanListDto dtoC = new PlanListDto("plan-C", "C 요금제", "1 GB", "0 GB", "50 분", "100 건",
+                    9900, 3,
                     List.of(), List.of());
 
             Slice<PlanListDto> sliceList = new SliceImpl<>(List.of(dtoA, dtoB, dtoC), pageable,


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 요금제 목록 조회 시 `Service` 계층에서 데이터를 int 타입에서 String 타입으로 변환 후 `Controller`에 반환하도록 수정했습니다.

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 데이터 무제한, 음성/메시지 기본제공은 데이터베이스에 -1을 저장하도록 구현했습니다.

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드는 삭제했어요.
