### PR TITLE
[fix]:[SCRUM-105] OAuth2 로그인 라다이랙트 url 환경에 따라 분기 처리

### DIFF
--- a/src/main/java/com/ixi_U/auth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/ixi_U/auth/handler/OAuth2SuccessHandler.java
@@ -26,11 +26,11 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
 
-        CustomOAuth2User CustomOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        CustomOAuth2User customOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
 
-        String userId = CustomOAuth2User.getUserId();
-        UserRole userRole = CustomOAuth2User.getUserRole();
-        Boolean isNewUser = CustomOAuth2User.isNewUser();
+        String userId = customOAuth2User.getUserId();
+        UserRole userRole = customOAuth2User.getUserRole();
+        Boolean isNewUser = customOAuth2User.isNewUser();
 
         log.info("userId = {}", userId);
         log.info("userRole = {}", userRole);
@@ -56,9 +56,14 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.addCookie(accessCookie);
         response.addCookie(refreshCookie);
 
-        String redirectUrl = CustomOAuth2User.isNewUser()
-                ? "http://localhost:3000/onboarding"
-                : "http://localhost:3000/plans";
+        String host = request.getHeader("host");
+        String frontBaseUrl = (host != null && host.contains("localhost"))
+                ? "http://localhost:3000"
+                : "https://ixiu.site";
+
+        String redirectUrl = isNewUser
+                ? frontBaseUrl + "/onboarding"
+                : frontBaseUrl + "/plans";
 
         response.sendRedirect(redirectUrl);
     }


### PR DESCRIPTION
## 📌 작업 개요
- OAuth2 로그인 성공 후 클라이언트로 리다이렉트되는 URL을 환경에 따라 동적으로 분기하도록 수정했습니다.
- 로컬에서는 http://localhost:3000, 배포 환경에서는 https://ixiu.site로 이동합니다.
- 기존에는 항상 localhost:3000으로 리다이렉트되어, 배포 환경에서 로그인 완료 후 정상 동작하지 않는 문제가 있었습니다.

## ✨ 기타 참고 사항
- 

## ✅ 체크리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [ ] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [ ] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [ ] 로컬 서버에서 정상 동작을 확인했어요.
- [ ] 불필요한 코드는 삭제했어요.
