### PR TITLE
[feat]:[SCRUM-102] 요금제 목록 조회 성능 고도화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,18 @@ bootJar {
 }
 
 dependencies {
+
+    // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly('io.jsonwebtoken:jjwt-jackson:0.11.5')
+
+    // Oauth2
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     // Hot Swap
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -68,18 +78,31 @@ dependencies {
     // Advisors
     implementation 'org.springframework.ai:spring-ai-advisors-vector-store'
 
+    // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // Bean Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Ahocorasick
+    implementation 'org.ahocorasick:ahocorasick:0.6.3'
+
+    // Open Korean Text
+    implementation("org.openkoreantext:open-korean-text:2.3.1")
+
+    // Spring Cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // Redis & Spring Data Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-
     testImplementation "org.testcontainers:junit-jupiter:1.21.1"
     testImplementation "org.testcontainers:neo4j:1.21.1"
-
-    // Bean Validation
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // Reactor Test
     testImplementation 'io.projectreactor:reactor-test:3.6.5'
@@ -89,19 +112,6 @@ dependencies {
     testImplementation 'org.springframework.restdocs:spring-restdocs-webtestclient:3.0.3'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-    // jwt
-    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    runtimeOnly('io.jsonwebtoken:jjwt-jackson:0.11.5')
-
-    // oauthAdd commentMore actions
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
-    // ahocorasick
-    implementation 'org.ahocorasick:ahocorasick:0.6.3'
-
-    // open korean text
-    implementation("org.openkoreantext:open-korean-text:2.3.1")
 }
 
 dependencyManagement {

--- a/src/main/java/com/ixi_U/IxiUApplication.java
+++ b/src/main/java/com/ixi_U/IxiUApplication.java
@@ -1,14 +1,16 @@
 package com.ixi_U;
 
 import jakarta.annotation.PostConstruct;
+import java.util.TimeZone;
 import org.springframework.ai.vectorstore.neo4j.autoconfigure.Neo4jVectorStoreAutoConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 
-import java.util.TimeZone;
-
-@SpringBootApplication(exclude = {SecurityAutoConfiguration.class, Neo4jVectorStoreAutoConfiguration.class})
+@EnableCaching
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class,
+        Neo4jVectorStoreAutoConfiguration.class})
 public class IxiUApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/ixi_U/common/config/RedisConfig.java
+++ b/src/main/java/com/ixi_U/common/config/RedisConfig.java
@@ -1,0 +1,62 @@
+package com.ixi_U.common.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper.DefaultTyping;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer() {
+        ObjectMapper om = new ObjectMapper();
+        om.registerModule(new JavaTimeModule());
+        om.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                DefaultTyping.EVERYTHING,
+                JsonTypeInfo.As.PROPERTY);
+        return new GenericJackson2JsonRedisSerializer(om);
+    }
+
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration(GenericJackson2JsonRedisSerializer gj) {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(gj));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory cf,
+            GenericJackson2JsonRedisSerializer gj) {
+
+        RedisTemplate<String, Object> tpl = new RedisTemplate<>();
+        tpl.setConnectionFactory(cf);
+        tpl.setKeySerializer(new StringRedisSerializer());
+        tpl.setValueSerializer(gj);
+        tpl.setHashKeySerializer(new StringRedisSerializer());
+        tpl.setHashValueSerializer(gj);
+
+        return tpl;
+    }
+}

--- a/src/main/java/com/ixi_U/plan/controller/PlanController.java
+++ b/src/main/java/com/ixi_U/plan/controller/PlanController.java
@@ -34,7 +34,7 @@ public class PlanController {
 
     @GetMapping("/plans")
     public ResponseEntity<SortedPlanResponse> getPlans(
-            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) String planTypeStr,
             @RequestParam(defaultValue = "PRIORITY") String planSortOptionStr,
             @RequestParam(required = false) String searchKeyword,

--- a/src/main/java/com/ixi_U/plan/controller/PlanController.java
+++ b/src/main/java/com/ixi_U/plan/controller/PlanController.java
@@ -34,7 +34,7 @@ public class PlanController {
 
     @GetMapping("/plans")
     public ResponseEntity<SortedPlanResponse> getPlans(
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String planTypeStr,
             @RequestParam(defaultValue = "PRIORITY") String planSortOptionStr,
             @RequestParam(required = false) String searchKeyword,

--- a/src/main/java/com/ixi_U/plan/controller/PlanController.java
+++ b/src/main/java/com/ixi_U/plan/controller/PlanController.java
@@ -1,23 +1,28 @@
 package com.ixi_U.plan.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.ixi_U.plan.dto.PlanNameDto;
 import com.ixi_U.plan.dto.request.GetPlansRequest;
 import com.ixi_U.plan.dto.request.SavePlanRequest;
-import com.ixi_U.plan.dto.response.*;
+import com.ixi_U.plan.dto.response.PlanAdminResponse;
+import com.ixi_U.plan.dto.response.PlanDetailResponse;
+import com.ixi_U.plan.dto.response.PlanEmbeddedResponse;
+import com.ixi_U.plan.dto.response.SortedPlanResponse;
 import com.ixi_U.plan.service.PlanService;
-import com.ixi_U.user.dto.request.OnboardingRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @Validated
@@ -30,11 +35,11 @@ public class PlanController {
     @GetMapping("/plans")
     public ResponseEntity<SortedPlanResponse> getPlans(
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam String planTypeStr,
+            @RequestParam(required = false) String planTypeStr,
             @RequestParam(defaultValue = "PRIORITY") String planSortOptionStr,
             @RequestParam(required = false) String searchKeyword,
             @RequestParam(required = false) String planId,
-            @RequestParam(required = false) Integer cursorSortValue){
+            @RequestParam(required = false) Integer cursorSortValue) {
 
         GetPlansRequest.validate(size);
         Pageable pageable = PageRequest.ofSize(size);
@@ -83,13 +88,13 @@ public class PlanController {
         return ResponseEntity.ok().build();
     }
 
-    
+
     // 요금제 목록 조회
     @GetMapping("/plans/summaries")
     public ResponseEntity<List<PlanNameDto>> getPlanNames() {
         return ResponseEntity.ok(planService.getPlanNameList());
     }
-        
+
     @GetMapping("/plans/embed")
     public ResponseEntity<Void> embedPlan() {
 

--- a/src/main/java/com/ixi_U/plan/dto/response/PlanAdminResponse.java
+++ b/src/main/java/com/ixi_U/plan/dto/response/PlanAdminResponse.java
@@ -9,7 +9,9 @@ public record PlanAdminResponse(
         PlanState planState,
         String usageCautions
 ) {
+
     public static PlanAdminResponse from(Plan plan) {
+
         return new PlanAdminResponse(
                 plan.getId(),
                 plan.getName(),

--- a/src/main/java/com/ixi_U/plan/dto/response/SortedPlanResponse.java
+++ b/src/main/java/com/ixi_U/plan/dto/response/SortedPlanResponse.java
@@ -1,9 +1,11 @@
 package com.ixi_U.plan.dto.response;
 
 import com.ixi_U.plan.dto.PlanListDto;
-import org.springframework.data.domain.Slice;
+import java.util.List;
 
-public record SortedPlanResponse(Slice<PlanListDto> plans, String lastPlanId,
+public record SortedPlanResponse(List<PlanListDto> plans,
+                                 boolean hasNext,
+                                 String lastPlanId,
                                  int lastSortValue) {
 
 }

--- a/src/main/java/com/ixi_U/plan/entity/PlanIndexInitializer.java
+++ b/src/main/java/com/ixi_U/plan/entity/PlanIndexInitializer.java
@@ -1,0 +1,45 @@
+package com.ixi_U.plan.entity;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.neo4j.core.Neo4jClient;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlanIndexInitializer {
+
+    private final Neo4jClient neo4jClient;
+
+    @PostConstruct
+    public void createIndexes() {
+
+        neo4jClient.query("""
+                    CREATE INDEX plan_priority_index IF NOT EXISTS FOR (p:Plan) ON (p.priority)
+                """).run();
+
+        neo4jClient.query("""
+                    CREATE INDEX plan_monthly_price_index IF NOT EXISTS FOR (p:Plan) ON (p.monthlyPrice)
+                """).run();
+
+        neo4jClient.query("""
+                    CREATE INDEX plan_data_index IF NOT EXISTS FOR (p:Plan) ON (p.mobileDataLimitMb)
+                """).run();
+
+        neo4jClient.query("""
+                    CREATE INDEX plan_type_index IF NOT EXISTS FOR (p:Plan) ON (p.planType)
+                """).run();
+
+        neo4jClient.query("""
+                    CREATE INDEX plan_state_index IF NOT EXISTS FOR (p:Plan) ON (p.planState)
+                """).run();
+
+        neo4jClient.query("""
+                    CREATE INDEX plan_active_duty_index IF NOT EXISTS FOR (p:Plan) ON (p.isActiveDuty)
+                """).run();
+
+        log.info("요금제 목록 조회 인덱스 생성 완료");
+    }
+}

--- a/src/main/java/com/ixi_U/plan/entity/PlanType.java
+++ b/src/main/java/com/ixi_U/plan/entity/PlanType.java
@@ -21,6 +21,11 @@ public enum PlanType {
 
     public static PlanType from(String type) {
 
+        if (type == null) {
+
+            return null;
+        }
+
         validatePlanType(type);
 
         return switch (type) {
@@ -34,7 +39,7 @@ public enum PlanType {
 
     private static void validatePlanType(String planTypeStr) {
 
-        if (planTypeStr == null || planTypeStr.isBlank()) {
+        if (planTypeStr.isBlank()) {
 
             throw new GeneralException(PlanException.INVALID_PLAN_TYPE);
         }

--- a/src/main/java/com/ixi_U/plan/repository/PlanRepositoryImpl.java
+++ b/src/main/java/com/ixi_U/plan/repository/PlanRepositoryImpl.java
@@ -31,7 +31,7 @@ public class PlanRepositoryImpl implements PlanCustomRepository {
 
         int limit = pageable.getPageSize();
         Map<String, Object> params = buildParams(planType, searchKeyword, planId, cursorSortValue);
-        Condition condition = buildCondition(planSortOption, searchKeyword, planId,
+        Condition condition = buildCondition(planType, planSortOption, searchKeyword, planId,
                 cursorSortValue);
 
         Node p = Cypher.node("Plan").named("p");
@@ -88,7 +88,10 @@ public class PlanRepositoryImpl implements PlanCustomRepository {
             Integer cursorSortValue) {
 
         Map<String, Object> params = new HashMap<>();
-        params.put("planType", planType.name());
+
+        if (planType != null) {
+            params.put("planType", planType.name());
+        }
 
         if (planId != null && cursorSortValue != null) {
             params.put("cursorSortValue", cursorSortValue);
@@ -101,13 +104,18 @@ public class PlanRepositoryImpl implements PlanCustomRepository {
         return params;
     }
 
-    private Condition buildCondition(PlanSortOption planSortOption, String searchKeyword,
+    private Condition buildCondition(PlanType planType, PlanSortOption planSortOption,
+            String searchKeyword,
             String planId, Integer cursorSortValue) {
 
         Node p = Cypher.node("Plan").named("p");
-        Condition condition = p.property("planType").eq(Cypher.parameter("planType"));
-        condition = condition.and(p.property("planState").ne(Cypher.literalOf("DISABLE")));
+        Condition condition = p.property("planState").ne(Cypher.literalOf("DISABLE"));
 
+        if (planType != null) {
+            condition = condition.and(
+                    p.property("planType").eq(Cypher.parameter("planType"))
+            );
+        }
         if (planId != null && cursorSortValue != null) {
             Condition sortCondition;
             if (planSortOption.getOrder() == SortOrder.ASC) {

--- a/src/main/java/com/ixi_U/plan/service/PlanService.java
+++ b/src/main/java/com/ixi_U/plan/service/PlanService.java
@@ -62,6 +62,10 @@ public class PlanService {
      * 요금제 저장 & 벡터 저장소에 저장
      */
     @Transactional
+    @CacheEvict(
+            value = {"planListPages"},
+            allEntries = true
+    )
     public PlanEmbeddedResponse savePlan(final SavePlanRequest request) {
 
         validateSamePlanName(request);
@@ -236,7 +240,10 @@ public class PlanService {
                 .toList();
     }
 
-    @CacheEvict(value = "planListPages", allEntries = true)
+    @CacheEvict(
+            value = {"planListPages"},
+            allEntries = true
+    )
     public void togglePlanState(String planId) {
         Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 요금제를 찾을 수 없습니다."));
@@ -249,7 +256,10 @@ public class PlanService {
     }
 
     @Transactional
-    @CacheEvict(value = "planListPages", allEntries = true)
+    @CacheEvict(
+            value = {"planListPages"},
+            allEntries = true
+    )
     public void disablePlan(String planId) {
         Plan plan = planRepository.findById(planId)
                 .orElseThrow(() -> new GeneralException(PlanException.PLAN_NOT_FOUND));

--- a/src/main/java/com/ixi_U/plan/service/PlanService.java
+++ b/src/main/java/com/ixi_U/plan/service/PlanService.java
@@ -181,19 +181,21 @@ public class PlanService {
     }
 
     private String convertCallLimit(int callLimitMinutes) {
-        return callLimitMinutes == -1 ? "기본제공" : String.valueOf(callLimitMinutes) + " 분";
+        return callLimitMinutes == Integer.MAX_VALUE ? "기본제공"
+                : String.valueOf(callLimitMinutes) + " 분";
     }
 
     private String convertMessageLimit(int messageLimit) {
-        return messageLimit == -1 ? "기본제공" : String.valueOf(messageLimit) + " 건";
+        return messageLimit == Integer.MAX_VALUE ? "기본제공" : String.valueOf(messageLimit) + " 건";
     }
 
     private String convertMobileData(int mobileDataLimitMb) {
-        return mobileDataLimitMb == -1 ? "무제한" : String.valueOf(mobileDataLimitMb / 1000) + " GB";
+        return mobileDataLimitMb == Integer.MAX_VALUE ? "무제한"
+                : String.valueOf(mobileDataLimitMb / 1000) + " GB";
     }
 
     private String convertSharedMobileDataLimitMb(int sharedMobileDataLimitMb) {
-        return sharedMobileDataLimitMb == -1 ? "무제한"
+        return sharedMobileDataLimitMb == Integer.MAX_VALUE ? "무제한"
                 : String.valueOf(sharedMobileDataLimitMb / 1000) + " GB";
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
     authentication:
       username: ${GRAPH_DB_USERNAME}
       password: ${GRAPH_DB_PASSWORD}
+    pool:
+      max-connection-pool-size: ${GRAPH_DB_MAX_CONNECTION_POOL_SIZE}
+      min-connection-pool-size: ${GRAPH_DB_MIN_CONNECTION_POOL_SIZE}
+      max-connection-lifetime: ${GRAPH_DB_MAX_CONNECTION_LIFETIME}
+      connection-acquisition-timeout: ${GRAPH_DB_CONNECTION_ACQUISITION_TIMEOUT}
 
   ai:
     openai:
@@ -34,6 +39,16 @@ spring:
       chat:
         options:
           model: ${OPEN_AI_CHAT_MODEL}
+
+  cache:
+    type: redis
+    redis:
+      time-to-live: ${REDIS_TTL}
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
 jwt:
   secret: ${JWT_SECRET_KEY}

--- a/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
@@ -49,7 +49,6 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -57,14 +56,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 @ActiveProfiles("test")
-@TestPropertySource(properties = {
-        "spring.cache.type=none",
-        "spring.cache.redis.time-to-live=10m",
-        "spring.neo4j.pool.connection-acquisition-timeout=30s",
-        "spring.neo4j.pool.max-connection-pool-size=100",
-        "spring.neo4j.pool.min-connection-pool-size=10",
-        "spring.neo4j.pool.max-connection-lifetime=3600s"
-})
 @WebMvcTest(PlanController.class)
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 class PlanControllerTest {

--- a/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
@@ -49,6 +49,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -56,6 +57,14 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 @ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "spring.cache.type=none",
+        "spring.cache.redis.time-to-live=10m",
+        "spring.neo4j.pool.connection-acquisition-timeout=30s",
+        "spring.neo4j.pool.max-connection-pool-size=100",
+        "spring.neo4j.pool.min-connection-pool-size=10",
+        "spring.neo4j.pool.max-connection-lifetime=3600s"
+})
 @WebMvcTest(PlanController.class)
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 class PlanControllerTest {

--- a/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
+++ b/src/test/java/com/ixi_U/plan/controller/PlanControllerTest.java
@@ -45,7 +45,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -176,8 +175,7 @@ class PlanControllerTest {
             PlanListDto dto2 = new PlanListDto("2", "요금제2", "무제한", "2000", "기본제공", "기본제공", 19000, 3,
                     List.of(), List.of());
 
-            SortedPlanResponse response = new SortedPlanResponse(
-                    new SliceImpl<>(List.of(dto1, dto2)), "2", 3);
+            SortedPlanResponse response = new SortedPlanResponse(List.of(dto1, dto2), true, "2", 3);
 
             given(planService.findPlans(PageRequest.ofSize(2), GetPlansRequest.of(
                     "ONLINE", "PRIORITY", null, null, null)))
@@ -190,12 +188,12 @@ class PlanControllerTest {
                             .param("planSortOptionStr", "PRIORITY")
                             .with(user("tester").roles("USER")))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.plans.content[0].id").value("1"))
-                    .andExpect(jsonPath("$.plans.content[0].mobileDataLimitMb").value("10GB"))
-                    .andExpect(jsonPath("$.plans.content[0].callLimitMinutes").value("300분"))
-                    .andExpect(jsonPath("$.plans.content[1].id").value("2"))
-                    .andExpect(jsonPath("$.plans.content[1].mobileDataLimitMb").value("무제한"))
-                    .andExpect(jsonPath("$.plans.content[1].callLimitMinutes").value("기본제공"))
+                    .andExpect(jsonPath("$.plans[0].id").value("1"))
+                    .andExpect(jsonPath("$.plans[0].mobileDataLimitMb").value("10GB"))
+                    .andExpect(jsonPath("$.plans[0].callLimitMinutes").value("300분"))
+                    .andExpect(jsonPath("$.plans[1].id").value("2"))
+                    .andExpect(jsonPath("$.plans[1].mobileDataLimitMb").value("무제한"))
+                    .andExpect(jsonPath("$.plans[1].callLimitMinutes").value("기본제공"))
                     .andExpect(jsonPath("$.lastPlanId").value("2"))
                     .andExpect(jsonPath("$.lastSortValue").value(3))
                     .andDo(document("get-plans-sort-success"))
@@ -209,8 +207,8 @@ class PlanControllerTest {
             // given
             PlanListDto dto2 = new PlanListDto("2", "요금제2", "8GB", "1000", "200분", "100건", 19000, 3,
                     List.of(), List.of());
-            SortedPlanResponse response =
-                    new SortedPlanResponse(new SliceImpl<>(List.of(dto2)), "2", 3);
+
+            SortedPlanResponse response = new SortedPlanResponse(List.of(dto2), true, "2", 3);
 
             given(planService.findPlans(PageRequest.ofSize(2), GetPlansRequest.of(
                     "ONLINE", "PRIORITY", "제2", null, null)))
@@ -224,7 +222,7 @@ class PlanControllerTest {
                             .param("searchKeyword", "제2")
                             .with(user("tester").roles("USER")))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.plans.content[0].id").value("2"))
+                    .andExpect(jsonPath("$.plans[0].id").value("2"))
                     .andExpect(jsonPath("$.lastPlanId").value("2"))
                     .andExpect(jsonPath("$.lastSortValue").value(3))
                     .andDo(document("get-plans-search-success"))

--- a/src/test/java/com/ixi_U/plan/repository/PlanRepositoryTest.java
+++ b/src/test/java/com/ixi_U/plan/repository/PlanRepositoryTest.java
@@ -58,6 +58,16 @@ class PlanRepositoryTest {
         registry.add("spring.neo4j.authentication.password", neo4jContainer::getAdminPassword);
     }
 
+    @DynamicPropertySource
+    static void redisProps(DynamicPropertyRegistry r) {
+        r.add("spring.cache.type", () -> "none");
+        r.add("spring.cache.redis.time-to-live", () -> "10m");
+        r.add("spring.neo4j.pool.connection-acquisition-timeout", () -> "30s");
+        r.add("spring.neo4j.pool.max-connection-pool-size", () -> "100");
+        r.add("spring.neo4j.pool.min-connection-pool-size", () -> "10");
+        r.add("spring.neo4j.pool.max-connection-lifetime", () -> "3600s");
+    }
+
     @Nested
     class findPlansTest {
 

--- a/src/test/java/com/ixi_U/plan/service/PlanServiceTest.java
+++ b/src/test/java/com/ixi_U/plan/service/PlanServiceTest.java
@@ -87,7 +87,7 @@ class PlanServiceTest {
             );
 
             // then
-            assertThat(result.plans().getContent()).containsExactly(dtoA, dtoB, dtoC);
+            assertThat(result.plans()).containsExactly(dtoA, dtoB, dtoC);
             verify(planRepository).findPlans(pageable, PlanType.from(planTypeStr),
                     PlanSortOption.from(planSortOptionStr), null, null, null
             );

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,3 +2,19 @@ spring:
   data:
     neo4j:
       database: neo4j
+
+    redis:
+      host: localhost
+      port: 6379
+
+  neo4j:
+    pool:
+      connection-acquisition-timeout: 30s
+      max-connection-pool-size: 100
+      min-connection-pool-size: 10
+      max-connection-lifetime: 3600s
+
+  cache:
+    type: redis
+    redis:
+      time-to-live: 60


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 요금제 목록 조회 시 Redis 캐시(@Cacheable)와 인덱스를 적용하여 조회 속도를 개선했습니다.
- Neo4j에 인덱스를 추가했습니다.
- Slice에서 List 반환 형식으로 수정하여 직렬화 이슈를 해결했습니다.

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- **Redis를 추가했으므로 노션의 `application.yml`을 반드시 확인해주세요!**
- 원래는 요금제 목록 조회할 때 `Slice<>` 형식을 반환했는데, 레디스 캐시에 저장한 후 불러올 때 역직렬화 문제가 발생하여 새로운 `List<>` 형식을 반환하는 방식으로 수정했습니다.
- 동시 사용자 1000명이 60초 동안 5000개의 요금제 데이터를 조회했을 때
  - 개선율(Avg): 31ms에서 6ms로 감소하여 **약 80%의 성능 개선**
  - 95th-percentile: 38ms에서 12ms로 감소하여 **약 68% 감소**
![](https://github.com/user-attachments/assets/91bed9e1-ca19-4ae9-916b-baf84dfea3a2)

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드는 삭제했어요.
