### PR TITLE
[feat]:[SCRUM-111] 요금제 개수 조회 기능 및 고도화

### DIFF
--- a/src/main/java/com/ixi_U/plan/controller/PlanController.java
+++ b/src/main/java/com/ixi_U/plan/controller/PlanController.java
@@ -6,10 +6,6 @@ import com.ixi_U.plan.dto.request.SavePlanRequest;
 import com.ixi_U.plan.dto.response.PlanAdminResponse;
 import com.ixi_U.plan.dto.response.PlanDetailResponse;
 import com.ixi_U.plan.dto.response.PlanEmbeddedResponse;
-import com.ixi_U.plan.dto.response.SortedPlanResponse;
-import com.ixi_U.plan.dto.response.PlanAdminResponse;
-import com.ixi_U.plan.dto.response.PlanDetailResponse;
-import com.ixi_U.plan.dto.response.PlanEmbeddedResponse;
 import com.ixi_U.plan.dto.response.PlansCountResponse;
 import com.ixi_U.plan.dto.response.SortedPlanResponse;
 import com.ixi_U.plan.service.PlanService;
@@ -98,7 +94,6 @@ public class PlanController {
         planService.disablePlan(planId);
         return ResponseEntity.ok().build();
     }
-
 
     // 요금제 목록 조회
     @GetMapping("/plans/summaries")

--- a/src/main/java/com/ixi_U/plan/controller/PlanController.java
+++ b/src/main/java/com/ixi_U/plan/controller/PlanController.java
@@ -7,6 +7,11 @@ import com.ixi_U.plan.dto.response.PlanAdminResponse;
 import com.ixi_U.plan.dto.response.PlanDetailResponse;
 import com.ixi_U.plan.dto.response.PlanEmbeddedResponse;
 import com.ixi_U.plan.dto.response.SortedPlanResponse;
+import com.ixi_U.plan.dto.response.PlanAdminResponse;
+import com.ixi_U.plan.dto.response.PlanDetailResponse;
+import com.ixi_U.plan.dto.response.PlanEmbeddedResponse;
+import com.ixi_U.plan.dto.response.PlansCountResponse;
+import com.ixi_U.plan.dto.response.SortedPlanResponse;
 import com.ixi_U.plan.service.PlanService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +54,12 @@ public class PlanController {
         SortedPlanResponse response = planService.findPlans(pageable, request);
 
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/plans/count")
+    public ResponseEntity<PlansCountResponse> countPlans() {
+
+        return ResponseEntity.ok(planService.countPlans());
     }
 
     @GetMapping("/plans/details/{planId}")

--- a/src/main/java/com/ixi_U/plan/dto/PlansCountDto.java
+++ b/src/main/java/com/ixi_U/plan/dto/PlansCountDto.java
@@ -1,0 +1,20 @@
+package com.ixi_U.plan.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PlansCountDto(int all, int fiveGLte, int online, int tabletSmartwatch,
+                            int dualNumber) {
+
+    public static PlansCountDto of(int all, int fiveGLte, int online, int tabletSmartwatch,
+            int dualNumber) {
+
+        return PlansCountDto.builder()
+                .all(all)
+                .fiveGLte(fiveGLte)
+                .online(online)
+                .tabletSmartwatch(tabletSmartwatch)
+                .dualNumber(dualNumber)
+                .build();
+    }
+}

--- a/src/main/java/com/ixi_U/plan/dto/response/PlansCountResponse.java
+++ b/src/main/java/com/ixi_U/plan/dto/response/PlansCountResponse.java
@@ -1,0 +1,20 @@
+package com.ixi_U.plan.dto.response;
+
+import com.ixi_U.plan.dto.PlansCountDto;
+import lombok.Builder;
+
+@Builder
+public record PlansCountResponse(int all, int fiveGLte, int online, int tabletSmartwatch,
+                                 int dualNumber) {
+
+    public static PlansCountResponse from(PlansCountDto plansCountDto) {
+
+        return PlansCountResponse.builder()
+                .all(plansCountDto.all())
+                .fiveGLte(plansCountDto.fiveGLte())
+                .online(plansCountDto.online())
+                .tabletSmartwatch(plansCountDto.tabletSmartwatch())
+                .dualNumber(plansCountDto.dualNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/ixi_U/plan/repository/PlanCustomRepository.java
+++ b/src/main/java/com/ixi_U/plan/repository/PlanCustomRepository.java
@@ -1,6 +1,7 @@
 package com.ixi_U.plan.repository;
 
 import com.ixi_U.plan.dto.PlanSummaryDto;
+import com.ixi_U.plan.dto.PlansCountDto;
 import com.ixi_U.plan.entity.PlanSortOption;
 import com.ixi_U.plan.entity.PlanType;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +13,5 @@ public interface PlanCustomRepository {
             PlanSortOption planSortOptionStr, String searchKeyword, String planId,
             Integer cursorSortValue);
 
+    PlansCountDto countPlans();
 }

--- a/src/main/java/com/ixi_U/plan/service/PlanService.java
+++ b/src/main/java/com/ixi_U/plan/service/PlanService.java
@@ -17,6 +17,7 @@ import com.ixi_U.plan.dto.request.SavePlanRequest;
 import com.ixi_U.plan.dto.response.PlanAdminResponse;
 import com.ixi_U.plan.dto.response.PlanDetailResponse;
 import com.ixi_U.plan.dto.response.PlanEmbeddedResponse;
+import com.ixi_U.plan.dto.response.PlansCountResponse;
 import com.ixi_U.plan.dto.response.SortedPlanResponse;
 import com.ixi_U.plan.entity.Plan;
 import com.ixi_U.plan.entity.PlanSortOption;
@@ -182,6 +183,12 @@ public class PlanService {
         int lastSortValue = getLastSortValue(plans, planSortOption);
 
         return new SortedPlanResponse(convertedPlanList, hasNext, lastPlanId, lastSortValue);
+    }
+
+    @Transactional(readOnly = true)
+    public PlansCountResponse countPlans() {
+
+        return PlansCountResponse.from(planRepository.countPlans());
     }
 
     private String convertCallLimit(int callLimitMinutes) {

--- a/src/main/java/com/ixi_U/plan/service/PlanService.java
+++ b/src/main/java/com/ixi_U/plan/service/PlanService.java
@@ -64,7 +64,7 @@ public class PlanService {
      */
     @Transactional
     @CacheEvict(
-            value = {"planListPages"},
+            value = {"planListPages", "planCounts"},
             allEntries = true
     )
     public PlanEmbeddedResponse savePlan(final SavePlanRequest request) {
@@ -186,6 +186,7 @@ public class PlanService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "planCounts", key = "'all'")
     public PlansCountResponse countPlans() {
 
         return PlansCountResponse.from(planRepository.countPlans());
@@ -248,7 +249,7 @@ public class PlanService {
     }
 
     @CacheEvict(
-            value = {"planListPages"},
+            value = {"planListPages", "planCounts"},
             allEntries = true
     )
     public void togglePlanState(String planId) {
@@ -264,7 +265,7 @@ public class PlanService {
 
     @Transactional
     @CacheEvict(
-            value = {"planListPages"},
+            value = {"planListPages", "planCounts"},
             allEntries = true
     )
     public void disablePlan(String planId) {


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 기능/버그를 작업했는지 간단히 설명해주세요 -->
- 요금제 개수 조회 기능을 추가했습니다.
- 요금제 개수 조회 기능에 캐싱을 적용했습니다.

## ✨ 기타 참고 사항
<!-- 리뷰어가 참고해야 할 사항이나, 보완 예정인 내용이 있다면 작성해주세요 -->
- 동시 사용자 1000명이 60초 동안 5000개의 요금제 데이터의 개수를 조회했을 때
  - 개선율(Avg): 13ms에서 4ms로 감소하여 **약 69%의 성능 개선**
  - 95th-percentile: 18ms에서 6ms로 감소하여 **약 66% 감소**

## ✅ 체크리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] Jira 티켓 아이디가 PR 제목 또는 커밋 메시지에 포함되어 있어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] `application.yml` 파일을 수정했다면, Notion에 업로드 및 공유했어요.
- [x] 로컬 서버에서 정상 동작을 확인했어요.
- [x] 불필요한 코드는 삭제했어요.
